### PR TITLE
fix: proposals filter default order

### DIFF
--- a/app/controllers/concerns/decidim/simple_proposal/proposals_controller_override.rb
+++ b/app/controllers/concerns/decidim/simple_proposal/proposals_controller_override.rb
@@ -186,11 +186,6 @@ module Decidim
             end
           end
         end
-
-        # TODO: Remove after feature/configurable_order_for_proposals is merged!
-        def default_order
-          "recent"
-        end
       end
     end
   end


### PR DESCRIPTION

🎩 Description
This removes a no more necessary method that replaced the proposals filter default order chosen by admin with "recent".

📌 Related Issues
[Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=90e91311d0d34edda7cb98c2e8a754e9&pm=c)

Testing
1. As an admin, go to a process
2. Go to the configuration of proposals component
3. Select in the "Default proposal sorting" , the "Default" value and update
4. Go to the process public page, go to proposals and see that the Order by filter is set to "Random" (which correspond to the default value, cf screenshot), and not "Recent"
5. As an admin, change the value of the "Default proposal sorting" and update
6. See in the public page that the filter is now set to the new value

Screenshot
<img width="1020" alt="Capture d’écran 2024-08-27 à 10 34 00" src="https://github.com/user-attachments/assets/9d9f293b-5646-4558-b5b3-c2c12f99b192">

