### PR TITLE
Fix scope in project edit in admin

### DIFF
--- a/app/helpers/concerns/decidim/simple_proposal/scopes_helper_override.rb
+++ b/app/helpers/concerns/decidim/simple_proposal/scopes_helper_override.rb
@@ -15,7 +15,8 @@ module Decidim
         def selected_scope(form)
           form.try(:scope_id) ||
             form.try(:settings).try(:scope_id) ||
-            form.try(:object).try(:scope_id)
+            form.try(:object).try(:scope_id) ||
+            form.try(:object).try(:decidim_scope_id)
         end
 
         def simple_scope_options(root: false, options: {})

--- a/spec/helpers/concerns/decidim/simple_proposal/scopes_helper_override_spec.rb
+++ b/spec/helpers/concerns/decidim/simple_proposal/scopes_helper_override_spec.rb
@@ -23,13 +23,38 @@ module Decidim
       end
     end
 
-    describe "selected_scope in project edit context" do
-      it "returns decidim_scope_id of form object" do
-        # we want to test this added case form.try(:object).try(:decidim_scope_id)
-        Object = Struct.new(:decidim_scope_id)
-        Myform = Struct.new(:object)
-        form = Myform.new(Object.new(10))
-        expect(selected_scope(form)).to eq(10)
+    describe "selected_scope method" do
+      Object = Struct.new(:scope_id, :decidim_scope_id)
+      Setting = Struct.new(:scope_id)
+      Myform = Struct.new(:scope_id, :settings, :object)
+
+      context "when form has a scope_id" do
+        it "returns scope_id" do
+          form = Myform.new(5, Setting.new(6), Object.new(7, 8))
+          expect(selected_scope(form)).to eq(5)
+        end
+      end
+
+      context "when form has no scope_id but has setting with scope_id" do
+        it "returns the scope_id of settings" do
+          form = Myform.new(nil, Setting.new(6), Object.new(7, 8))
+          expect(selected_scope(form)).to eq(6)
+        end
+      end
+
+      context "when form has no scope_id, no settings but has object with scope_id" do
+        it "returns the scope_id of object" do
+          form = Myform.new(nil, nil, Object.new(7, 8))
+          expect(selected_scope(form)).to eq(7)
+        end
+      end
+
+      context "when form has no scope_id, no settings but has object with decidim_scope_id and without scope_id" do
+        # this is the case we added, which corresponds to project edit in admin
+        it "returns the decidim_scope_id of object" do
+          form = Myform.new(nil, nil, Object.new(nil, 8))
+          expect(selected_scope(form)).to eq(8)
+        end
       end
     end
   end

--- a/spec/helpers/concerns/decidim/simple_proposal/scopes_helper_override_spec.rb
+++ b/spec/helpers/concerns/decidim/simple_proposal/scopes_helper_override_spec.rb
@@ -22,5 +22,15 @@ module Decidim
         expect(result).not_to include(third_scope, fourth_scope)
       end
     end
+
+    describe "selected_scope in project edit context" do
+      it "returns decidim_scope_id of form object" do
+        # we want to test this added case form.try(:object).try(:decidim_scope_id)
+        Object = Struct.new(:decidim_scope_id)
+        Myform = Struct.new(:object)
+        form = Myform.new(Object.new(10))
+        expect(selected_scope(form)).to eq(10)
+      end
+    end
   end
 end


### PR DESCRIPTION
🎩 Description
When we open the edit of a project with a scope, the value of the scope is not selected in the view.

📌 Related Issues
[Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=7499cc6cc01041248a7e3a85b6b4814d&pm=c)

Testing
1. As an admin, go to a process and then to budgets
2. Click on "Manage projects" of a budget (cf screenshot one)
3. Go to the edit of a project which has a scope (cf screenshot two)
4. In the edit view, see that the scope is selected (cf screenshot three)

Screenshots
ONE 
<img width="1280" alt="Capture d’écran 2024-09-02 à 09 26 41" src="https://github.com/user-attachments/assets/e5575e3c-95d1-439e-829a-cdaf3a41e8da">

TWO
<img width="1275" alt="Capture d’écran 2024-09-02 à 09 28 18" src="https://github.com/user-attachments/assets/1bb084de-99c0-4127-8c13-05c6e8fd28e8">

THREE
<img width="1251" alt="Capture d’écran 2024-09-02 à 09 29 36" src="https://github.com/user-attachments/assets/904a54fa-b836-4207-a42f-9affcfcf4535">


